### PR TITLE
Fix logs for OrderCancelledListener

### DIFF
--- a/delivery-app/backend/delivery-service/src/main/java/com/delivery/delivery/listener/OrderCancelledListener.java
+++ b/delivery-app/backend/delivery-service/src/main/java/com/delivery/delivery/listener/OrderCancelledListener.java
@@ -26,14 +26,14 @@ public class OrderCancelledListener {
     public void handleOrderCancelled(Message message, Channel channel) throws IOException {
         try {
             Order order = objectMapper.readValue(message.getBody(), Order.class);
-            log.info("Received DELIVERED order event: {}", order);
+            log.info("Received CANCELLED order event: {}", order);
 
             commons.updateAssignmentAndDriverStatus(order, "cancelled");
 
             // ACK manual: confirmamos que el mensaje fue procesado correctamente
             channel.basicAck(message.getMessageProperties().getDeliveryTag(), false);
         } catch (Exception e) {
-            log.error("Error processing delivered order: {}", e.getMessage(), e);
+            log.error("Error processing cancelled order: {}", e.getMessage(), e);
 
             try {
                 // NACK manual: rechazamos el mensaje, lo podemos requeuear o no


### PR DESCRIPTION
## Summary
- correct log messages on order cancellation event

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448d2633d083249b3a8e377c35871d