### PR TITLE
Update file service ports and docs

### DIFF
--- a/delivery-app/backend/file-service/Dockerfile
+++ b/delivery-app/backend/file-service/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /app
 
 COPY build/libs/file-service-1.0.0.jar app.jar
 
-EXPOSE 8085
+EXPOSE 8086
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/delivery-app/backend/file-service/README.md
+++ b/delivery-app/backend/file-service/README.md
@@ -14,12 +14,16 @@ Microservicio para gestión de archivos en MinIO (desarrollo) o AWS S3 (producci
 - `minio.url`
 - `minio.access-key`
 - `minio.secret-key`
+- `minio.bucket-name`
 - `aws.s3.bucket`
-- `aws.accessKeyId`
-- `aws.secretAccessKey`
+- `aws.s3.access-key`
+- `aws.s3.secret-key`
+- `aws.s3.region`
+- `aws.s3.endpoint`
 
 ## Docker
 ```bash
 ./gradlew clean build
 docker build -t file-service .
-docker run -p 8085:8085 file-service
+docker run -p 8086:8086 file-service
+```


### PR DESCRIPTION
## Summary
- update file-service Dockerfile to expose port 8086
- document correct properties in file-service README
- fix port and close code block in README

## Testing
- `./backend/file-service/gradlew -p backend/file-service test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448d2bafac83248518d09df6336096