### PR TITLE
Fix JWT expiration property

### DIFF
--- a/delivery-app/backend/auth-service/build/resources/main/application-prod.yml
+++ b/delivery-app/backend/auth-service/build/resources/main/application-prod.yml
@@ -31,4 +31,4 @@ springdoc:
 
 jwt:
   secret: mysecretkeymysecretkeymysecretkey1234
-  expirationMs: 86400000 # 1 día
+  expiration: 86400000 # 1 día

--- a/delivery-app/backend/auth-service/src/main/resources/application-prod.yml
+++ b/delivery-app/backend/auth-service/src/main/resources/application-prod.yml
@@ -31,4 +31,4 @@ springdoc:
 
 jwt:
   secret: mysecretkeymysecretkeymysecretkey1234
-  expirationMs: 86400000 # 1 día
+  expiration: 86400000 # 1 día


### PR DESCRIPTION
## Summary
- rename `expirationMs` key to `expiration` in `auth-service` prod config

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68448d28891c832487dd6ad0143378fe