### PR TITLE
Add safety checks to infra scripts

### DIFF
--- a/setup_local_infra.sh
+++ b/setup_local_infra.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+set -euo pipefail
+
+# Check prerequisites
+usage() {
+    echo "Usage: $0"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: docker is required."
+    usage
+    exit 1
+fi
+
+if ! command -v docker-compose >/dev/null 2>&1; then
+    echo "Error: docker-compose is required."
+    usage
+    exit 1
+fi
 
 # Crear la raíz del proyecto
 mkdir -p delivery-app/infrastructure/postgres

--- a/start_infra_and_show_urls.sh
+++ b/start_infra_and_show_urls.sh
@@ -1,4 +1,22 @@
 #!/bin/bash
+set -euo pipefail
+
+# Check prerequisites
+usage() {
+    echo "Usage: $0"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: docker is required."
+    usage
+    exit 1
+fi
+
+if ! command -v docker-compose >/dev/null 2>&1; then
+    echo "Error: docker-compose is required."
+    usage
+    exit 1
+fi
 
 # Levantar todo con docker-compose
 echo "Levantando infraestructura local con Docker Compose..."


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to bash scripts
- check docker and docker-compose availability
- print usage when requirements are missing

## Testing
- `bash -n setup_local_infra.sh`
- `bash -n start_infra_and_show_urls.sh`


------
https://chatgpt.com/codex/tasks/task_e_68449b07c5ec8324b4ad54f7bbfab867