### PR TITLE
Add JSON logging pipeline

### DIFF
--- a/delivery-app/backend/auth-service/build.gradle
+++ b/delivery-app/backend/auth-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/delivery-app/backend/auth-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/auth-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/backend/catalog-service/build.gradle
+++ b/delivery-app/backend/catalog-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/delivery-app/backend/catalog-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/catalog-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/backend/delivery-service/build.gradle
+++ b/delivery-app/backend/delivery-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/delivery-app/backend/delivery-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/delivery-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/backend/file-service/build.gradle
+++ b/delivery-app/backend/file-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/delivery-app/backend/file-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/file-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/backend/gateway-service/build.gradle
+++ b/delivery-app/backend/gateway-service/build.gradle
@@ -19,6 +19,7 @@ dependencyManagement {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'    // ESTA ES LA CORRECTA
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/delivery-app/backend/gateway-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/gateway-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/backend/order-service/build.gradle
+++ b/delivery-app/backend/order-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/delivery-app/backend/order-service/src/main/resources/logback-spring.xml
+++ b/delivery-app/backend/order-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.json</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/delivery-app/docker-compose.yml
+++ b/delivery-app/docker-compose.yml
@@ -85,6 +85,9 @@ services:
     container_name: logstash
     ports:
       - "5000:5000"
+    volumes:
+      - ./infrastructure/logstash/pipeline:/usr/share/logstash/pipeline
+      - ./logs:/logs
     networks:
       - delivery-network
 
@@ -106,6 +109,8 @@ services:
       - postgres
     environment:
       SPRING_PROFILES_ACTIVE: local
+    volumes:
+      - ./logs/catalog-service:/app/logs
     networks:
       - delivery-network
 
@@ -119,6 +124,8 @@ services:
       - postgres
     environment:
       SPRING_PROFILES_ACTIVE: local
+    volumes:
+      - ./logs/order-service:/app/logs
     networks:
       - delivery-network
 
@@ -132,6 +139,8 @@ services:
       - postgres
     environment:
       SPRING_PROFILES_ACTIVE: local
+    volumes:
+      - ./logs/delivery-service:/app/logs
     networks:
       - delivery-network
 
@@ -145,6 +154,8 @@ services:
       - postgres
     environment:
       SPRING_PROFILES_ACTIVE: local
+    volumes:
+      - ./logs/auth-service:/app/logs
     networks:
       - delivery-network
   
@@ -159,6 +170,8 @@ services:
     depends_on:
       - rabbitmq
       - minio
+    volumes:
+      - ./logs/gateway-service:/app/logs
     networks:
       - delivery-network
 
@@ -172,6 +185,8 @@ services:
       - SPRING_PROFILES_ACTIVE=local
     depends_on:
       - rabbitmq
+    volumes:
+      - ./logs/file-service:/app/logs
     networks:
       - delivery-network
 

--- a/delivery-app/docs/logging.md
+++ b/delivery-app/docs/logging.md
@@ -1,0 +1,10 @@
+# Viewing Logs
+
+Logs from each microservice are written in JSON format under `./logs/<service>`.
+Logstash reads these files and sends events to ElasticSearch. To review them in Grafana:
+
+1. Start the infrastructure using `docker-compose up`.
+2. Access Grafana at [http://localhost:3000](http://localhost:3000) with `admin`/`admin`.
+3. Add ElasticSearch as a data source pointing to `http://elasticsearch:9200`.
+4. Import or create a dashboard using the `delivery-logs-*` index.
+5. Use Logs or Table panels to explore log entries.

--- a/delivery-app/infrastructure/logstash/pipeline/logstash.conf
+++ b/delivery-app/infrastructure/logstash/pipeline/logstash.conf
@@ -1,0 +1,15 @@
+input {
+  file {
+    path => "/logs/*/*.json"
+    start_position => "beginning"
+    sincedb_path => "/usr/share/logstash/data/sincedb"
+    codec => json
+  }
+}
+output {
+  elasticsearch {
+    hosts => "http://elasticsearch:9200"
+    index => "delivery-logs-%{+YYYY.MM.dd}"
+  }
+  stdout { codec => rubydebug }
+}


### PR DESCRIPTION
## Summary
- add `logback-spring.xml` to each microservice
- output JSON logs to files
- add Logstash pipeline and mount log volumes in `docker-compose.yml`
- document how to view logs in Grafana

## Testing
- `./gradlew test` in `delivery-app/backend/auth-service`

------
https://chatgpt.com/codex/tasks/task_e_68449b06ff5483249f61060ab5b5db02