### PR TITLE
Add core service tests

### DIFF
--- a/delivery-app/backend/catalog-service/src/test/java/com/delivery/catalog/service/ProductServiceTest.java
+++ b/delivery-app/backend/catalog-service/src/test/java/com/delivery/catalog/service/ProductServiceTest.java
@@ -1,0 +1,63 @@
+package com.delivery.catalog.service;
+
+import com.delivery.catalog.model.Product;
+import com.delivery.catalog.model.ProductSearch;
+import com.delivery.catalog.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private ProductElasticsearchService productElasticsearchService;
+
+    private ProductService productService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        productService = new ProductService(productRepository, productElasticsearchService);
+    }
+
+    @Test
+    void updateStockUpdatesProductWhenStockValid() {
+        Product existing = Product.builder().id(1L).name("Apple").stockKg(10.0).build();
+        Product ordered = Product.builder().id(1L).stockKg(5.0).build();
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        productService.updateStock(Collections.singletonList(ordered)).block();
+
+        assertEquals(5.0, existing.getStockKg());
+        verify(productRepository).save(existing);
+        verify(productElasticsearchService).save(any(ProductSearch.class));
+    }
+
+    @Test
+    void updateStockFailsWhenNegative() {
+        Product existing = Product.builder().id(1L).name("Apple").stockKg(10.0).build();
+        Product ordered = Product.builder().id(1L).stockKg(-1.0).build();
+
+        when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                productService.updateStock(Collections.singletonList(ordered)).block());
+
+        assertTrue(ex.getMessage().contains("Stock insuficiente"));
+        verify(productRepository, never()).save(any());
+    }
+}

--- a/delivery-app/backend/delivery-service/src/test/java/com/delivery/delivery/service/AssignmentServiceTest.java
+++ b/delivery-app/backend/delivery-service/src/test/java/com/delivery/delivery/service/AssignmentServiceTest.java
@@ -1,0 +1,66 @@
+package com.delivery.delivery.service;
+
+import com.delivery.delivery.client.OrderClient;
+import com.delivery.delivery.model.Assignment;
+import com.delivery.delivery.model.Driver;
+import com.delivery.delivery.repository.AssignmentRepository;
+import com.delivery.delivery.repository.DriverRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentServiceTest {
+
+    @Mock
+    private AssignmentRepository assignmentRepository;
+    @Mock
+    private DriverRepository driverRepository;
+    @Mock
+    private OrderClient orderClient;
+    @Mock
+    private AssignmentElasticsearchService assignmentElasticsearchService;
+
+    private AssignmentService assignmentService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        assignmentService = new AssignmentService(assignmentRepository, driverRepository, orderClient, assignmentElasticsearchService);
+    }
+
+    @Test
+    void assignOrderCreatesAssignmentWhenDriverAvailable() {
+        Driver driver = Driver.builder().id(1L).available(true).build();
+        when(driverRepository.findById(1L)).thenReturn(Optional.of(driver));
+        when(assignmentRepository.save(any(Assignment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(orderClient.updateOrderStatus(anyLong(), anyString())).thenReturn(Mono.empty());
+
+        Assignment result = assignmentService.assignOrder(2L, 1L).block();
+
+        assertNotNull(result);
+        assertEquals("assigned", result.getStatus());
+        verify(assignmentRepository).save(any(Assignment.class));
+        verify(driverRepository).save(driver);
+        verify(orderClient).updateOrderStatus(2L, "assigned");
+    }
+
+    @Test
+    void assignOrderFailsWhenDriverNotAvailable() {
+        Driver driver = Driver.builder().id(1L).available(false).build();
+        when(driverRepository.findById(1L)).thenReturn(Optional.of(driver));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> assignmentService.assignOrder(2L, 1L).block());
+        assertEquals("Driver is not available", ex.getMessage());
+        verify(assignmentRepository, never()).save(any());
+    }
+}

--- a/delivery-app/backend/order-service/src/test/java/com/delivery/order/service/OrderServiceTest.java
+++ b/delivery-app/backend/order-service/src/test/java/com/delivery/order/service/OrderServiceTest.java
@@ -1,0 +1,82 @@
+package com.delivery.order.service;
+
+import com.delivery.order.client.CatalogClient;
+import com.delivery.order.event.OrderEventPublisher;
+import com.delivery.order.model.Order;
+import com.delivery.order.repository.OrderRepository;
+import com.delivery.order.model.Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private CatalogClient catalogClient;
+    @Mock
+    private OrderEventPublisher orderEventPublisher;
+    @Mock
+    private OrderElasticsearchService orderElasticsearchService;
+
+    private OrderService orderService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        orderService = new OrderService(orderRepository, catalogClient, orderEventPublisher, orderElasticsearchService);
+    }
+
+    @Test
+    void markOrderAsPaidUpdatesOrderWhenDelivered() {
+        Order order = Order.builder()
+                .id(1L)
+                .status("delivered")
+                .paidToMerchant(false)
+                .createdDate(LocalDateTime.now())
+                .products(Collections.emptyList())
+                .build();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Order result = orderService.markOrderAsPaid(1L).block();
+
+        assertNotNull(result);
+        assertTrue(result.getPaidToMerchant());
+        verify(orderEventPublisher).publishOrderPaid(any(Order.class));
+        verify(orderElasticsearchService).save(any());
+        verify(orderRepository).save(any(Order.class));
+    }
+
+    @Test
+    void markOrderAsPaidFailsWhenNotDelivered() {
+        Order order = Order.builder()
+                .id(1L)
+                .status("pending")
+                .paidToMerchant(false)
+                .products(Collections.emptyList())
+                .build();
+
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> orderService.markOrderAsPaid(1L).block());
+        assertEquals("Solo puedes pagar pedidos entregados", ex.getMessage());
+        verify(orderRepository, never()).save(any());
+        verify(orderEventPublisher, never()).publishOrderPaid(any());
+    }
+}


### PR DESCRIPTION
## Summary
- cover `OrderService.markOrderAsPaid` success and failure
- cover `ProductService.updateStock` success and failure
- cover `AssignmentService.assignOrder` success and failure

## Testing
- `./gradlew test` in `order-service`
- `./gradlew test` in `catalog-service`
- `./gradlew test` in `delivery-service`


------
https://chatgpt.com/codex/tasks/task_e_68449b09d8208324ae0c6cb06b947b99