### PR TITLE
Aggregate OpenAPI docs on gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ All services are implemented using Spring Boot and expose reactive REST APIs.
 
 Support services like PostgreSQL, Redis, RabbitMQ, MinIO, Prometheus, Grafana and the ELK stack are also started by Docker Compose.
 
+## API Documentation
+
+The gateway aggregates the OpenAPI specifications of all microservices. Open the
+Swagger UI at [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+and select the desired service from the dropdown.
+

--- a/delivery-app/backend/gateway-service/src/main/java/com/delivery/gateway/config/GatewayConfig.java
+++ b/delivery-app/backend/gateway-service/src/main/java/com/delivery/gateway/config/GatewayConfig.java
@@ -33,6 +33,22 @@ public class GatewayConfig {
                 .route("file-service", r -> r.path("/api/files/**")
                         .filters(f -> f.filter(authenticationFilter))
                         .uri("http://file-service:8086"))
+                // OpenAPI documentation endpoints for each microservice
+                .route("auth-service-docs", r -> r.path("/api/docs/auth")
+                        .filters(f -> f.rewritePath("/api/docs/auth", "/v3/api-docs"))
+                        .uri("http://auth-service:8084"))
+                .route("catalog-service-docs", r -> r.path("/api/docs/catalog")
+                        .filters(f -> f.rewritePath("/api/docs/catalog", "/v3/api-docs"))
+                        .uri("http://catalog-service:8081"))
+                .route("order-service-docs", r -> r.path("/api/docs/order")
+                        .filters(f -> f.rewritePath("/api/docs/order", "/v3/api-docs"))
+                        .uri("http://order-service:8082"))
+                .route("delivery-service-docs", r -> r.path("/api/docs/delivery")
+                        .filters(f -> f.rewritePath("/api/docs/delivery", "/v3/api-docs"))
+                        .uri("http://delivery-service:8083"))
+                .route("file-service-docs", r -> r.path("/api/docs/file")
+                        .filters(f -> f.rewritePath("/api/docs/file", "/v3/api-docs"))
+                        .uri("http://file-service:8086"))
                 .build();
     }
 }

--- a/delivery-app/backend/gateway-service/src/main/resources/application-local.yml
+++ b/delivery-app/backend/gateway-service/src/main/resources/application-local.yml
@@ -22,3 +22,19 @@ management:
 
 jwt:
   secret: mysecretkeymysecretkeymysecretkey1234
+
+springdoc:
+  swagger-ui:
+    urls:
+      - name: gateway
+        url: /v3/api-docs
+      - name: auth-service
+        url: /api/docs/auth
+      - name: catalog-service
+        url: /api/docs/catalog
+      - name: order-service
+        url: /api/docs/order
+      - name: delivery-service
+        url: /api/docs/delivery
+      - name: file-service
+        url: /api/docs/file

--- a/delivery-app/backend/gateway-service/src/main/resources/application-prod.yml
+++ b/delivery-app/backend/gateway-service/src/main/resources/application-prod.yml
@@ -12,3 +12,19 @@ management:
 
 jwt:
   secret: ${JWT_SECRET} # en producción se lee de variable de entorno
+
+springdoc:
+  swagger-ui:
+    urls:
+      - name: gateway
+        url: /v3/api-docs
+      - name: auth-service
+        url: /api/docs/auth
+      - name: catalog-service
+        url: /api/docs/catalog
+      - name: order-service
+        url: /api/docs/order
+      - name: delivery-service
+        url: /api/docs/delivery
+      - name: file-service
+        url: /api/docs/file


### PR DESCRIPTION
## Summary
- expose OpenAPI endpoints of each service through the gateway
- configure Swagger UI in the gateway to list all service docs
- document the aggregated Swagger UI URL

## Testing
- `./gradlew build` in `gateway-service`

------
https://chatgpt.com/codex/tasks/task_e_6844a861c8208324a2f09dfe41698654