### PR TITLE
Add missing service READMEs

### DIFF
--- a/delivery-app/backend/auth-service/README.md
+++ b/delivery-app/backend/auth-service/README.md
@@ -1,17 +1,23 @@
 # Auth Service
 
-Microservicio de autenticación para la plataforma DeliveryApp.
+Authentication microservice responsible for user registration, login and JWT token issuance.
 
-## Tecnologías
+## Running locally
 
-- Java 21
-- Spring Boot 3.3.0
-- Spring WebFlux
-- Spring Security + JWT
-- R2DBC (PostgreSQL)
-- Swagger OpenAPI para WebFlux
+Start the infrastructure from the repository root:
 
-## Correr localmente
+```bash
+./start_infra_and_show_urls.sh
+```
+
+Then launch the service with the `local` profile (port **8084**):
 
 ```bash
 ./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## Key endpoints
+
+- `POST /api/auth/register` – register a new user
+- `POST /api/auth/login` – obtain access and refresh tokens
+- `POST /api/auth/refresh` – refresh the access token

--- a/delivery-app/backend/catalog-service/README.md
+++ b/delivery-app/backend/catalog-service/README.md
@@ -1,17 +1,33 @@
 # Catalog Service
 
-This microservice exposes the product catalog API.
+Service responsible for managing products and categories.
 
-## Running Locally
+## Running locally
 
-Use Docker Compose to start the infrastructure, including PostgreSQL and Redis:
+Start the infrastructure from the repository root:
 
 ```bash
 ./start_infra_and_show_urls.sh
 ```
 
-Run the service with the `local` profile (already configured in the compose file). It connects to Redis on `redis:6379`.
+Then launch the service on port **8081** using the `local` profile:
 
-## Redis Caching
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
 
-The service uses Spring Cache backed by Redis to cache the list of products. Cached data is refreshed when products are created or stock is updated.
+## Key endpoints
+
+- `GET /api/products` – list all products
+- `POST /api/products` – create a product
+- `POST /api/products/update-stock` – update stock after an order
+- `POST /api/products/{id}/files` – upload images for a product
+- `GET /api/categories` – list categories
+- `POST /api/categories` – create a category
+- `GET /api/products/search` – list indexed products
+- `GET /api/products/search/{id}` – get indexed product by id
+- `GET /api/products/search/name/{name}` – search product by name
+
+## Redis caching
+
+Products are cached in Redis and invalidated when new products are added or stock changes.

--- a/delivery-app/backend/delivery-service/README.md
+++ b/delivery-app/backend/delivery-service/README.md
@@ -1,0 +1,26 @@
+# Delivery Service
+
+Tracks drivers and assignments for delivering orders.
+
+## Running locally
+
+Start the infrastructure:
+
+```bash
+./start_infra_and_show_urls.sh
+```
+
+Run the service on port **8083** with the `local` profile:
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## Key endpoints
+
+- `GET /api/drivers` – list drivers
+- `POST /api/drivers` – create a driver
+- `GET /api/assignments` – list assignments
+- `POST /api/assignments?orderId=&driverId=` – assign an order to a driver
+- `PATCH /api/assignments/{id}?status=` – update assignment status
+- `GET /api/assignments/available-orders` – orders available for assignment

--- a/delivery-app/backend/file-service/README.md
+++ b/delivery-app/backend/file-service/README.md
@@ -1,16 +1,29 @@
 # File Service - DeliveryApp
 
-Microservicio para gestión de archivos en MinIO (desarrollo) o AWS S3 (producción).
+Handles file uploads using MinIO for local development or S3 in production.
+
+## Running locally
+
+Start the infrastructure from the repository root:
+
+```bash
+./start_infra_and_show_urls.sh
+```
+
+Launch the service on port **8086** with:
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
 
 ## Endpoints
-- POST `/api/files/upload` : Subir archivo
-- GET `/api/files/download/{filename}` : Descargar archivo
+- `POST /api/files/upload` – upload a file
 
-## Perfiles
-- `local` → usa MinIO
-- `prod` → usa AWS S3 (preparado para futura integración)
+## Profiles
+- `local` → uses MinIO
+- `prod` → prepared for AWS S3
 
-## Variables importantes
+## Important variables
 - `minio.url`
 - `minio.access-key`
 - `minio.secret-key`

--- a/delivery-app/backend/gateway-service/README.md
+++ b/delivery-app/backend/gateway-service/README.md
@@ -1,0 +1,30 @@
+# Gateway Service
+
+Spring Cloud Gateway acting as the single entry point for all backend services. It applies JWT authentication and routes requests to the underlying microservices.
+
+## Running locally
+
+Start the supporting infrastructure:
+
+```bash
+./start_infra_and_show_urls.sh
+```
+
+Run the gateway on port **8080**:
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## Key endpoints
+
+The gateway forwards requests to each service using these base paths:
+
+- `/api/auth/**` → auth-service
+- `/api/products/**` and `/api/categories/**` → catalog-service
+- `/api/orders/**` → order-service
+- `/api/drivers/**` and `/api/assignments/**` → delivery-service
+- `/api/files/**` → file-service
+
+OpenAPI documentation for all services is available at:
+`http://localhost:8080/swagger-ui.html`.

--- a/delivery-app/backend/order-service/README.md
+++ b/delivery-app/backend/order-service/README.md
@@ -1,0 +1,29 @@
+# Order Service
+
+Handles order creation, status updates and merchant reporting.
+
+## Running locally
+
+Start the required infrastructure:
+
+```bash
+./start_infra_and_show_urls.sh
+```
+
+Run the service on port **8082** with the `local` profile:
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local'
+```
+
+## Key endpoints
+
+- `GET /api/orders` – list all orders
+- `GET /api/orders/pending` – list pending orders
+- `POST /api/orders` – create a new order
+- `PATCH /api/orders/{id}?status=` – update order status
+- `GET /api/orders/merchant/{merchantId}/sales` – orders for a merchant
+- `GET /api/orders/merchant/{merchantId}/sales-summary` – sales summary for a merchant
+- `GET /api/orders/merchant/{merchantId}/pending-payments` – orders awaiting payment
+- `PATCH /api/orders/mark-paid/{orderId}` – mark order as paid
+- `GET /api/orders/merchant/{merchantId}/financial-summary?startDate=&endDate=` – financial summary


### PR DESCRIPTION
## Summary
- document how to run each backend service locally
- list the main endpoints for every service

## Testing
- `./gradlew test` in auth-service
- `./gradlew test` in catalog-service
- `./gradlew test` in order-service
- `./gradlew test` in delivery-service

------
https://chatgpt.com/codex/tasks/task_e_6844b4bedc0883248909de1c17dc06fa